### PR TITLE
typo in method name fixed in RF

### DIFF
--- a/RoboChrome.roboFontExt/lib/RoboChromeUI.py
+++ b/RoboChrome.roboFontExt/lib/RoboChromeUI.py
@@ -58,7 +58,7 @@ def get_ui(window_controller, title):
         },
         {
             "title": "Color",
-            "cell": RFColorCell.alloc().initWithDoubleClickCallack_(window_controller.paletteEditColorCell),
+            "cell": RFColorCell.alloc().initWithDoubleClickCallback_(window_controller.paletteEditColorCell),
             "typingSensitive": False,
             "editable": False,
         },


### PR DESCRIPTION
see [RoboChrome not loading? (RoboFont Forum)](https://forum.robofont.com/topic/737/robochrome-not-loading)

this fixes RoboChrome in RF 3.3, but (probably) breaks it in previous versions…

maybe there’s an elegant way to keep it backwards compatible?

thanks in advance for looking into it!